### PR TITLE
Feature-UpdateCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 sudo: required
-dist: xenial
+dist: bionic
 language: cpp
 
 matrix:
   include:
     - os: osx
+      osx_image: xcode10.3
       compiler: clang
       env: BUILD_TYPE=Debug
       env: CXXFLAGS=-fno-var-tracking
     - os: osx
+      osx_image: xcode10.3
       compiler: clang
       env: BUILD_TYPE=Release
       env: CXXFLAGS=-fno-var-tracking

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,8 +28,8 @@ pipeline {
                         }
                     }
                 }
-                stage('MacOSSierra') {
-                    agent { label "MacOSSierra" }
+                stage('MacOSAir') {
+                    agent { label "MacOSAir" }
                     steps {
                         checkout scm
                         sh 'mkdir -p build-debug'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,8 +195,8 @@ pipeline {
                         }
                     }
                 }
-                stage('MacOSSierra') {
-                    agent { label "MacOSSierra" }
+                stage('MacOSAir') {
+                    agent { label "MacOSAir" }
                     steps {
                         checkout scm
                         sh 'mkdir -p build-release'


### PR DESCRIPTION
The Jenkinsfile was missing an entry for MacOSAir, but contained MacOSSierra, which is being retired.  Updated the travis file to use 18.04 linux (although linux doesn't occur in the build matrix.  Started forcing the use of an OSX image that has Xcode 10.3.